### PR TITLE
Don't add resources without duration as fastest resource

### DIFF
--- a/core/speedgun.js
+++ b/core/speedgun.js
@@ -212,7 +212,11 @@ var speedgun = {
             slowest = resource;
           }
           if (!fastest || resource.times.start !== 0 || resource.duration < fastest.duration) {
-            fastest = resource;
+            // we catch resources with empty durations, we should look at the root of the evil
+            // but for now, just don't add them to the list
+            if (resource.duration !== '') {
+              fastest = resource;
+            }
           }
           //console.log(totalDuration);
           totalDuration += resource.duration;


### PR DESCRIPTION
A fix for #10. So we have resources with an empty duration field, I guess there could be something wrong somewhere, but I only did a quick fix to not make them the fastest resource :)


