### PR TITLE
Skip data uri:s from the fastest/slowest list #25

### DIFF
--- a/core/speedgun.js
+++ b/core/speedgun.js
@@ -201,19 +201,20 @@ var fs = require('fs'),
         for (var resource in resources) {
           resource = resources[resource];
 
-  //        if (resources.hasOwnProperty(resource)) {
+          //        if (resources.hasOwnProperty(resource)) {
           if (!resource.times.start || !resource.times.end) {
             //if one of start or end times is undefined - don't calculate
             resource.times.start = resource.times.end = 0;
           }
 
-          if (!slowest || resource.times.start !== 0 || resource.duration > slowest.duration) {
+          if ((!slowest || resource.times.start !== 0 || resource.duration > slowest.duration) && (!resource.url.match(/(^data:.+\/.*)/i))) {
             slowest = resource;
           }
           if (!fastest || resource.times.start !== 0 || resource.duration < fastest.duration) {
             // we catch resources with empty durations, we should look at the root of the evil
-            // but for now, just don't add them to the list
-            if (resource.duration !== '') {
+            // but for now, just don't add them to the list. And exclude DATA uri:s
+
+            if (resource.duration !== '' && (!resource.url.match(/(^data:.+\/.*)/i))) {
               fastest = resource;
             }
           }


### PR DESCRIPTION
added so we skip data uri:s from fastest/slowest, kept them though for the size list. skipping them there will make the logic easier though.